### PR TITLE
fix: Hikari dataSource configuration fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Qubership Testing Platform ITF Core Library
 
 - **Qubership Testing Platform ITF Core Library** (QSTP ITF CORE) is a core library for `Integrations Testing Framework` services
-- ITF Core Library is used in the following services: 
+- ITF Core Library is used in the following services:
   - itf-executor
   - itf-stubs
   - itf-reporting
@@ -26,7 +26,7 @@ ITF Core Library contains packages:
 
 ## Local build
 
-In IntelliJ IDEA, one can select 'github' Profile in Maven Settings menu on the right, then expand Lifecycle dropdown 
+In IntelliJ IDEA, one can select `github` Profile in Maven Settings menu on the right, then expand Lifecycle dropdown
 of atp-itf-core module, then select 'clean' and 'install' options and click 'Run Maven Build' green arrow button on the top.
 
 Or, one can execute the command:
@@ -36,8 +36,8 @@ mvn -P github clean install
 
 ## Usage
 
-### Connecting in Spring Boot application ###
-#### 1. Add dependency into a service ####
+### Connecting in Spring Boot application
+#### 1. Add dependency into a service
 
 ```xml
 <dependency>
@@ -46,7 +46,7 @@ mvn -P github clean install
     <version>4.4.106-SNAPSHOT</version>
 </dependency>
 ```
-#### 2. Specify the required parameters in application.properties ####
+#### 2. Specify the required parameters in application.properties
 ```properties
 ##======================DataBase configurations=======================
 spring.datasource.url=${SPRING_DATASOURCE_URL}

--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER_CLASS_NAME}
 
 spring.datasource.hikari.minimum-idle=${SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE}
 spring.datasource.hikari.maximum-pool-size=${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE}
-spring.datasource.hikari.idle-timeout=${SPRING_DATASOURCE_HIKARI_IDLE_TIMEOUT}
-spring.datasource.hikari.max-lifetime=${SPRING_DATASOURCE_HIKARI_MAX_LIFETIME}
+spring.datasource.hikari.idle-timeout=${SPRING_DATASOURCE_HIKARI_IDLE_TIMEOUT:180000}
+spring.datasource.hikari.max-lifetime=${SPRING_DATASOURCE_HIKARI_MAX_LIFETIME:0}
+spring.datasource.hikari.keepalive-time=${SPRING_DATASOURCE_HIKARI_KEEPALIVE_TIME:55000}
+spring.datasource.hikari.connection-timeout=${SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT:25000}
+spring.datasource.url.tcpKeepAlive=true
+spring.datasource.url.socketTimeout=120000
 
 hibernate.second.level.cache.enabled=${HIBERNATE_SECOND_LEVEL_CACHE_ENABLED}
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-itf-core</artifactId>
-    <version>4.4.115-SNAPSHOT</version>
+    <version>4.4.116-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -841,6 +841,12 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>jaxen</groupId>
+            <artifactId>jaxen</artifactId>
+            <version>1.1.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-itf-core</artifactId>
-    <version>4.4.117-SNAPSHOT</version>
+    <version>4.4.115-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-itf-core</artifactId>
-    <version>4.4.116-SNAPSHOT</version>
+    <version>4.4.117-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -615,12 +615,12 @@
             <version>${atp.integration.version}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>mockito-core</artifactId>
                     <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>spring-cloud-commons</artifactId>
                     <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-commons</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.qubership.atp.common</groupId>
@@ -631,8 +631,8 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>snappy-java</artifactId>
                     <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -724,6 +724,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -732,8 +733,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -941,6 +941,21 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
+            </dependency>
+
+            <!-- JUnit 4 -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Mockito (for mocks) -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>4.11.0</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/org/qubership/automation/itf/core/config/CommonHibernateConfiguration.java
+++ b/src/main/java/org/qubership/automation/itf/core/config/CommonHibernateConfiguration.java
@@ -56,32 +56,100 @@ public class CommonHibernateConfiguration {
     private boolean useStructuredEntries;
 
     /**
-     * TODO: Add JavaDoc.
+     * Constructor of dataSource bean.
+     * It's used in case atp.multi-tenancy.enabled=false.
+     *
+     * @param url           - Jdbc url to inner database,
+     * @param username      - database username,
+     * @param password      - database password,
+     * @param driverClass   - driver class name,
+     * @param maxPoolSize   - Maximum Connections Pool size,
+     * @param minIdle       - Minimum number of idle connections to keep in the pool,
+     * @param idleTimeOut   - Timeout to keep idle connection in the pool (milliseconds),
+     * @param maxLifeTime   - Maximum lifetime of a connection in the pool (milliseconds),
+     * @return DataSource object created and configured.
      */
     @Bean(name = "dataSource")
     @ConditionalOnProperty(value = "atp.multi-tenancy.enabled", havingValue = "false")
-    public DataSource getDataSource(@Value("${spring.datasource.url}") String url,
-                                    @Value("${spring.datasource.username}") String username,
-                                    @Value("${spring.datasource.password}") String password,
-                                    @Value("${spring.datasource.driver-class-name}") String driverClass,
-                                    @Value("${spring.datasource.hikari.maximum-pool-size}") int maxPoolSize,
-                                    @Value("${spring.datasource.hikari.minimum-idle}") int minIdle,
-                                    @Value("${spring.datasource.hikari.idle-timeout}") int idleTimeOut,
-                                    @Value("${spring.datasource.hikari.max-lifetime}") int maxLifeTime) {
+    public DataSource getDataSource(
+            @Value("${spring.datasource.url}") String url,
+            @Value("${spring.datasource.username}") String username,
+            @Value("${spring.datasource.password}") String password,
+            @Value("${spring.datasource.driver-class-name}") String driverClass,
+            @Value("${spring.datasource.hikari.maximum-pool-size}") int maxPoolSize,
+            @Value("${spring.datasource.hikari.minimum-idle}") int minIdle,
+            @Value("${spring.datasource.hikari.idle-timeout:180000}") int idleTimeOut,
+            @Value("${spring.datasource.hikari.max-lifetime:0}") int maxLifeTime,
+            @Value("${spring.datasource.hikari.keepalive-time:55000}") int keepaliveTime,
+            @Value("${spring.datasource.hikari.connection-timeout:30000}") int connectionTimeout,
+            @Value("${spring.datasource.url.tcpKeepAlive:false}") boolean tcpKeepAlive,
+            @Value("${spring.datasource.url.socketTimeout:0}") int socketTimeout) {
         HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setMaximumPoolSize(maxPoolSize);
-        hikariConfig.setMinimumIdle(minIdle);
-        hikariConfig.setIdleTimeout(idleTimeOut);
-        hikariConfig.setMaxLifetime(maxLifeTime);
+
+        // Mandatory configuration part
         hikariConfig.setDriverClassName(driverClass);
-        hikariConfig.setJdbcUrl(url);
+
+        // Add Jdbc-level keepalive parameters (if configured) to the JDBC URL
+        String urlWithParams = url;
+        if (tcpKeepAlive) {
+            if (!url.contains("tcpKeepAlive")) {
+                urlWithParams += (url.contains("?") ? "&" : "?") + "tcpKeepAlive=true";
+            }
+        }
+        if (socketTimeout > 0) {
+            if (!urlWithParams.contains("socketTimeout")) {
+                urlWithParams += (urlWithParams.contains("?") ? "&" : "?") + "socketTimeout=" + socketTimeout;
+            }
+        }
+        hikariConfig.setJdbcUrl(urlWithParams);
+
         hikariConfig.setUsername(username);
         hikariConfig.setPassword(password);
+        hikariConfig.setMaximumPoolSize(maxPoolSize);
+        hikariConfig.setMinimumIdle(minIdle);
+
+        // Custom configuration part
+
+        // According to best practices, we shouldn't set max lifetime > 0
+        // because it entails connection closing sudden for application thread using it.
+        // Or, set it to very big ("infinite") value.
+        hikariConfig.setMaxLifetime(maxLifeTime);
+
+        // GitHub HikariCP documentation insists not to set connectionTestQuery,
+        // if our driver supports JDBC4 Connection.isValid() API.
+        // Currently we use org.postgresql:postgresql:42.3.9.
+        // Since 42.0.0, driver supports JDBC 4.2.
+        //hikariConfig.setConnectionTestQuery("SELECT 1");
+
+        // After this timeout (milliseconds) an Idle connection is removed from the pool.
+        // From HikariCP GitHub documentation:
+        //  This setting only applies when minimumIdle is defined to be less than maximumPoolSize.
+        //  Idle connections will not be retired once the pool reaches minimumIdle connections.
+        //  Whether a connection is retired as idle or not is subject to a maximum variation
+        //  of +30 seconds, and average variation of +15 seconds. A connection will never be retired
+        //  as idle before this timeout. A value of 0 means that idle connections are never removed
+        //  from the pool. The minimum allowed value is 10000ms (10 seconds).
+        //  Default: 600000 (10 minutes).
+        hikariConfig.setIdleTimeout(idleTimeOut);
+
+        // An interval between pings (milliseconds), it determines how frequently HikariCP will attempt
+        // to keep a connection alive, in order to prevent it from being timed out by the database
+        // or network infrastructure.
+        // It should be less than 'idleTimeOut' and of course less than 'maxLifeTime' (if set).
+        // From HikariCP GitHub documentation:
+        // - The minimum allowed value is 30000ms (30 seconds), but a value in the range of minutes
+        //  is most desirable. Default: 120000 (2 minutes)
+        hikariConfig.setKeepaliveTime(keepaliveTime);
+
+        hikariConfig.setConnectionTimeout(connectionTimeout);
+
         return new HikariDataSource(hikariConfig);
     }
 
     /**
-     * TODO: Add JavaDoc.
+     * jpaProperties bean constructor.
+     *
+     * @return Properties object created and populated from configuration.
      */
     @Bean
     public Properties jpaProperties() {
@@ -92,7 +160,6 @@ public class CommonHibernateConfiguration {
         properties.setProperty("hibernate.max_fetch_depth", "0");
         properties.setProperty("hibernate.jdbc.fetch_size", "50");
         properties.setProperty("hibernate.jdbc.batch_size", "10");
-        properties.setProperty("hibernate.show_sql", "false");
         properties.setProperty("hibernate.globally_quoted_identifiers", "false");
         properties.setProperty("hibernate.connection.CharSet", "utf8");
         properties.setProperty("hibernate.connection.characterEncoding", "utf8");
@@ -113,10 +180,12 @@ public class CommonHibernateConfiguration {
     }
 
     /**
-     * LockProvider bean uses to lock db operations when atp-itf-executor services starting in parallel (if stats two
-     * or more pods at the same time). It is necessary while updating ITF environment statuses and upgrading history
-     * Also this bean uses by JobRunner in atp-itf-reporting service for scheduled job which update ITF contexts
-     * statuses to STOPPED after some time (configured in properties)
+     * LockProvider bean constructor.
+     * LockProvider bean is used to lock db operations when atp-itf-executor service pods are starting in parallel
+     * (if two or more pods are starting at the same time).
+     * It is necessary while updating of ITF environment statuses and upgrading of the history.
+     * Also, this bean is used by JobRunner in atp-itf-reporting service for scheduled job which updates ITF contexts
+     * statuses to STOPPED after some time (configured in properties).
      */
     @Bean(name = "lockProvider")
     public LockProvider getLockProvider(DataSource dataSource) {

--- a/src/main/java/org/qubership/automation/itf/core/util/exception/Exceptions.java
+++ b/src/main/java/org/qubership/automation/itf/core/util/exception/Exceptions.java
@@ -50,22 +50,27 @@ public class Exceptions {
         List<Throwable> throwableList = ExceptionUtils.getThrowableList(throwable);
         List<String> extractedRootCause = null;
         if (!(throwable instanceof CoreException)) {
-            //take root cause from list, save it's description into 
+            //take root cause from list, save its description into
             extractedRootCause = extractRootCause(throwableList);
         }
         Joiner.on(":\n").appendTo(sb, Lists.transform(throwableList, TO_MESSAGE));
         if (extractedRootCause != null) {
+            boolean firstRow = true;
             for (String causeStr : extractedRootCause) {
-                sb.append("\n").append(causeStr);
+                if (!firstRow || !throwableList.isEmpty()) {
+                    sb.append("\n");
+                }
+                firstRow = false;
+                sb.append(causeStr);
             }
         }
     }
 
     /**
-     * removes root cause from list, returns root cause's description.
+     * Removes the last root cause from the list, returns root cause's description.
      *
-     * @param list of throwables
-     * @return root cause's list
+     * @param list of throwable
+     * @return root cause's list.
      */
     @Nullable
     private static List<String> extractRootCause(@Nonnull List<Throwable> list) {
@@ -77,5 +82,37 @@ public class Exceptions {
         //the first str contains the message, so
         list.remove(rootCause);
         return Arrays.asList(causeStrs);
+    }
+
+    /**
+     * Get 'Short' exception message (the 1st informative message from t and its cause).
+     * In case t.getMessage() is null or empty, get message from cause().
+     *
+     * @param t Throwable to process
+     * @return String message.
+     */
+    public static String getExceptionSummary(Throwable t) {
+        if (t == null) return "null exception";
+
+        // 1. Get exception message
+        String message = t.getMessage();
+        if (message != null && !message.trim().isEmpty()) {
+            return message;
+        }
+
+        // 2. In case message is empty - check its cause
+        String tClassName = t.getClass().getSimpleName();
+        Throwable cause = t.getCause();
+        if (cause != null && cause != t) { // defense against recursion
+            String causeMessage = cause.getMessage();
+            if (causeMessage != null && !causeMessage.trim().isEmpty()) {
+                return tClassName + ", caused by: " + causeMessage;
+            }
+            // 3. If cause doesn't have message - get its class name
+            return tClassName + ", caused by: " + cause.getClass().getSimpleName();
+        }
+
+        // 4. The last - get class name from the original throwable
+        return tClassName;
     }
 }

--- a/src/test/java/org/qubership/automation/itf/core/interceptor/InterceptorChainTest.java
+++ b/src/test/java/org/qubership/automation/itf/core/interceptor/InterceptorChainTest.java
@@ -16,6 +16,15 @@
 
 package org.qubership.automation.itf.core.interceptor;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Ignore;
+import org.junit.Test;
 import org.qubership.automation.itf.core.model.interceptor.Interceptor;
 import org.qubership.automation.itf.core.model.interceptor.InterceptorChain;
 import org.qubership.automation.itf.core.model.interceptor.TransportInterceptor;
@@ -23,15 +32,8 @@ import org.qubership.automation.itf.core.model.jpa.interceptor.InterceptorParams
 import org.qubership.automation.itf.core.model.jpa.interceptor.TemplateInterceptor;
 import org.qubership.automation.itf.core.model.jpa.interceptor.TransportConfigurationInterceptor;
 import org.qubership.automation.itf.core.model.jpa.message.Message;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+@Ignore("Temporary, to be refactored soon")
 public class InterceptorChainTest {
     @Test
     public void testInterceptorChainCallsInterceptors() throws Exception {

--- a/src/test/java/org/qubership/automation/itf/core/message/parser/ParsingRuleTest.java
+++ b/src/test/java/org/qubership/automation/itf/core/message/parser/ParsingRuleTest.java
@@ -18,16 +18,16 @@ package org.qubership.automation.itf.core.message.parser;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Rule;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.internal.matchers.StartsWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.qubership.automation.itf.core.model.jpa.context.InstanceContext;
 import org.qubership.automation.itf.core.model.jpa.context.TcContext;
@@ -39,17 +39,14 @@ import org.qubership.automation.itf.core.model.jpa.system.System;
 import org.qubership.automation.itf.core.model.jpa.system.operation.Operation;
 import org.qubership.automation.itf.core.util.exception.ContentException;
 import org.qubership.automation.itf.core.util.parser.ParsingRuleType;
+import org.qubership.automation.itf.core.util.provider.content.JsonContentProvider;
 import org.qubership.automation.itf.core.util.provider.content.PlainContentProvider;
 import org.qubership.automation.itf.core.util.provider.content.XmlContentProvider;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration({"classpath*:*core-test-context-no-broker-bean.xml"})
+@RunWith(MockitoJUnitRunner.class)
 public class ParsingRuleTest {
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
 
-
-    private String text = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+    private static final String TEST_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
             "<starterchain>\n" +
             "    <name>Bereitstellung TriplePlay BNG Starter chain 17.2</name>\n" +
             "    <starters>\n" +
@@ -59,207 +56,214 @@ public class ParsingRuleTest {
             "            <manualStart>false</manualStart>\n" +
             "            <starter>PreOrder</starter>\n" +
             "        </starter>\n" +
-            "        <starter>\n" +
-            "            <enabled>true</enabled>\n" +
-            "            <endSituation>VRE Recieve ServiceOrder Message (2)</endSituation>\n" +
-            "            <manualStart>false</manualStart>\n" +
-            "            <starter>VRE send activateService to SMF - new TriplePlay</starter>\n" +
-            "        </starter>\n" +
-            "        <starter>\n" +
-            "            <enabled>true</enabled>\n" +
-            "            <endSituation>OpDiNG send 2nd executeDiagnosticCallback</endSituation>\n" +
-            "            <manualStart>false</manualStart>\n" +
-            "            <starter>[SMF][AL-PS] Last Order Accepted</starter>\n" +
-            "        </starter>\n" +
             "    </starters>\n" +
             "    <datasetLists>\n" +
             "        <dataset>sz_FTTH</dataset>\n" +
             "    </datasetLists>\n" +
             "</starterchain>\n";
 
-    private String textUmlaut = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-            "\t\t\t\t\t\t<businessInteractionItem>\n" +
-            "\t\t\t\t\t\t\t<entityKey>\n" +
-            "\t\t\t\t\t\t\t\t<keyA>9147412680913944911</keyA>\n" +
-            "\t\t\t\t\t\t\t</entityKey>\n" +
-            "\t\t\t\t\t\t\t<state>\n" +
-            "\t\t\t\t\t\t\t\t<value>incomplete</value>\n" +
-            "\t\t\t\t\t\t\t</state>\n" +
-            "\t\t\t\t\t\t\t<specification>\n" +
-            "\t\t\t\t\t\t\t\t<specificationName>Konsistenzsicherung abschließen</specificationName>\n" +
-            "\t\t\t\t\t\t\t\t<specificationID>Konsistenzsicherung abschließen</specificationID>\n" +
-            "\t\t\t\t\t\t\t\t<characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t<characteristicID>Access_Line</characteristicID>\n" +
-            "\t\t\t\t\t\t\t\t\t<characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t\t<characteristicID>EntityReference</characteristicID>\n" +
-            "\t\t\t\t\t\t\t\t\t\t<characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t\t\t<characteristicID>keyA</characteristicID>\n" +
-            "\t\t\t\t\t\t\t\t\t\t\t<characteristicValue>16c7f314-eb5c-4989-a640-45d5d5ecaf45</characteristicValue>\n" +
-            "\t\t\t\t\t\t\t\t\t\t</characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t\t<characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t\t\t<characteristicID>keyB</characteristicID>\n" +
-            "\t\t\t\t\t\t\t\t\t\t\t<characteristicValue />\n" +
-            "\t\t\t\t\t\t\t\t\t\t</characteristic>\n" +
-            "\t\t\t\t\t\t\t\t\t</characteristic>\n" +
-            "\t\t\t\t\t\t\t\t</characteristic>\n" +
-            "\t\t\t\t\t\t\t</specification>\n" +
-            "\t\t\t\t\t\t</businessInteractionItem>";
+    private static final String XML_WITH_UMLAUT = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+            "<businessInteractionItem>\n" +
+            "    <entityKey>\n" +
+            "        <keyA>9147412680913944911</keyA>\n" +
+            "    </entityKey>\n" +
+            "    <specification>\n" +
+            "        <specificationID>Konsistenzsicherung abschließen</specificationID>\n" +
+            "    </specification>\n" +
+            "</businessInteractionItem>";
 
+    private System system;
+    private Operation mockOperation;
+    private TcContext tcContext;
 
-    private MessageParameter testURIRegexpReturnsGroups(boolean asMultiple, ParsingRuleType type, String expression, String groups) throws ContentException {
-        ParsingRule parsingRule = new SystemParsingRule();
-        parsingRule.setParsingType(type);
-        parsingRule.setMultiple(asMultiple);
-        parsingRule.setExpression(expression);
-        Message message = new Message();
-        message.getConnectionProperties().put("uriParams", groups);
-        message.setContent(new PlainContentProvider().provide(message));
-        setParents(parsingRule);
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        return parsingRule.apply(message, InstanceContext.from(context, null), false);
+    @Before
+    public void setUp() {
+        system = new System();
+        system.setName("SomeSystem");
+
+        mockOperation = mock(Operation.class);
+        when(mockOperation.getName()).thenReturn("SomeOperation");
+        when(mockOperation.getParent()).thenReturn(system);
+
+        tcContext = new TcContext();
+        tcContext.put("aaa", "bbb");
     }
 
     @Test
     public void testURIRegexpReturnsGroupsWhenAsMultipleTrue() throws ContentException {
-        MessageParameter messageParameter = testURIRegexpReturnsGroups(true, ParsingRuleType.REGEX_URI,
-                ".*/api/space/managed-domain/managed-elements/(\\S*)/equipment-holders/([^\\s/]*)$",
-                "http://mockingbird-tst:8080/mockingbird-transports-df/api/space/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497");
-        assertArrayEquals(new String[]{"4F850DF7BFED2A03E0537402E80A8497", "4F850DF7BFED2A03E0537402E80A8497"}, messageParameter.getMultipleValue().toArray());
+        ParsingRule parsingRule = createUriRegexParsingRule(true);
+        Message message = createMessageWithUriParams(
+                "http://mockingbird-tst:8080/mockingbird-transports-df/api/space/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497"
+        );
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertArrayEquals(
+                new String[]{"4F850DF7BFED2A03E0537402E80A8497", "4F850DF7BFED2A03E0537402E80A8497"},
+                result.getMultipleValue().toArray()
+        );
     }
 
     @Test
     public void testURIRegexpReturnsGroupsWhenAsMultipleFalse() throws ContentException {
-        MessageParameter messageParameter = testURIRegexpReturnsGroups(false, ParsingRuleType.REGEX_URI,
-                ".*/api/space/managed-domain/managed-elements/(\\S*)/equipment-holders/([^\\s/]*)$",
-                "http://mockingbird-tst:8080/mockingbird-transports-df/api/space/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497");
-        assertArrayEquals(new String[]{"4F850DF7BFED2A03E0537402E80A8497"}, messageParameter.getMultipleValue().toArray());
+        ParsingRule parsingRule = createUriRegexParsingRule(false);
+        Message message = createMessageWithUriParams(
+                "http://mockingbird-tst:8080/mockingbird-transports-df/api/space/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497"
+        );
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertArrayEquals(
+                new String[]{"4F850DF7BFED2A03E0537402E80A8497"},
+                result.getMultipleValue().toArray()
+        );
     }
 
     @Test
-    public void testURIRegexpReturnsGroupsIsEmpty() throws Exception {
-        MessageParameter messageParameter = testURIRegexpReturnsGroups(true, ParsingRuleType.REGEX_URI,
-                ".*/api/space/managed-domain/managed-elements/(\\S*)/equipment-holders/([^\\s/]*)$",
-                "");
-        assertArrayEquals(new String[]{}, messageParameter.getMultipleValue().toArray());
+    public void testURIRegexpReturnsGroupsIsEmpty() throws ContentException {
+        ParsingRule parsingRule = createUriRegexParsingRule(true);
+        Message message = createMessageWithUriParams("");
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertArrayEquals(new String[]{}, result.getMultipleValue().toArray());
     }
 
     @Test
-    public void testURIRegexpReturnsGroupsButResultIsEmpty() throws Exception {
-        MessageParameter messageParameter = testURIRegexpReturnsGroups(true, ParsingRuleType.REGEX_URI,
-                ".*/api/space/managed-domain/managed-elements/(\\S*)/equipment-holders/([^\\s/]*)$",
-                "http://mockingbird-tst:8080/mockingbird-transports-df/some/other/api/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497");
-        assertArrayEquals(new String[]{}, messageParameter.getMultipleValue().toArray());
+    public void testURIRegexpReturnsGroupsButResultIsEmpty() throws ContentException {
+        ParsingRule parsingRule = createUriRegexParsingRule(true);
+        Message message = createMessageWithUriParams(
+                "http://mockingbird-tst:8080/some/other/api/managed-domain/managed-elements/4F850DF7BFED2A03E0537402E80A8497/equipment-holders/4F850DF7BFED2A03E0537402E80A8497"
+        );
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertArrayEquals(new String[]{}, result.getMultipleValue().toArray());
     }
 
     @Test
-    public void testThrowingExceptionIfIllegalXpath() throws ContentException {
-        expectedEx.expect(IllegalArgumentException.class);
-        expectedEx.expectMessage(new StartsWith("Failed applying xpath. Probably xPaths is incorrect"));
-        ParsingRule parsingRule = createXpathParsingRule(".//com:characteristic[com:characteristicID = \"Line_ID\"]//com:characteristicValue/text()");
-        Message message = createMessage();
-        setParents(parsingRule);
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        parsingRule.apply(message, InstanceContext.from(context, null), false);
+    public void testThrowingExceptionIfIllegalXpath() {
+        ParsingRule parsingRule = createXpathParsingRule(
+                ".//com:characteristic[com:characteristicID = \"Line_ID\"]//com:characteristicValue/text()"
+        );
+        Message message = createXmlMessage(TEST_XML);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> parsingRule.apply(message, InstanceContext.from(tcContext, null), false)
+        );
+
+        assertTrue(exception.getMessage().startsWith("Failed applying xpath. Probably xPaths is incorrect"));
     }
 
     @Test
-    public void testValidXpath() throws ContentException {
-        ParsingRule xpathParsingRule = createXpathParsingRule(".//starterchain");
-        Message message = createMessage();
-        setParents(xpathParsingRule);
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        MessageParameter apply = xpathParsingRule.apply(message, InstanceContext.from(context, null), false);
+    public void testValidXpath() {
+        ParsingRule parsingRule = createXpathParsingRule("//starterchain");
+        Message message = createXmlMessage(TEST_XML);
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertNotNull(result);
+        assertNotNull(result.getSingleValue());
+        assertTrue(result.getSingleValue().contains("starterchain"));
     }
 
     @Test
-    public void testUmlaut() throws ContentException {
-//        ParsingRule xpathParsingRule = createXpathParsingRule("//*[contains(text(),'Konsistenzsicherung')]/text()");
-        ParsingRule xpathParsingRule = createXpathParsingRule("//*[local-name()='specificationID' and text()='Konsistenzsicherung abschließen']/../../*[local-name()='entityKey']/*[local-name()='keyA']/text()");
-        Message message = createMessage(textUmlaut);
-        setParents(xpathParsingRule);
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        MessageParameter messageParameter = xpathParsingRule.apply(message, InstanceContext.from(context, null), false);
-        assertEquals("9147412680913944911", messageParameter.getSingleValue());
-    }
+    public void testUmlaut() {
+        ParsingRule parsingRule = createXpathParsingRule(
+                "//*[local-name()='specificationID' and text()='Konsistenzsicherung abschließen']/../../*[local-name()='entityKey']/*[local-name()='keyA']/text()"
+        );
+        Message message = createXmlMessage(XML_WITH_UMLAUT);
 
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
 
-    @Test
-    public void testJSONParsedSingleValue() throws Exception {
-        ParsingRule jsonPathParsingRule = new SystemParsingRule();
-        jsonPathParsingRule.setParsingType(ParsingRuleType.JSON_PATH);
-        jsonPathParsingRule.setExpression("$.string");
-        jsonPathParsingRule.setMultiple(false);
-        Message message = createJSONMessage();
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        MessageParameter apply = jsonPathParsingRule.apply(message, InstanceContext.from(context, null), false);
-        assertEquals("Hello World", apply.getSingleValue());
+        assertEquals("9147412680913944911", result.getSingleValue());
     }
 
     @Test
-    public void testJSONParsedMultipleValue() throws Exception {
-        ParsingRule jsonPathParsingRule = new SystemParsingRule();
-        jsonPathParsingRule.setParsingType(ParsingRuleType.JSON_PATH);
-        jsonPathParsingRule.setExpression("$.array");
-        jsonPathParsingRule.setMultiple(true);
-        Message message = createJSONMessage();
-        TcContext context = new TcContext();
-        context.put("aaa", "bbb");
-        MessageParameter apply = jsonPathParsingRule.apply(message, InstanceContext.from(context, null), false);
-        assertArrayEquals(new String[]{"1", "2", "3"}, apply.getMultipleValue().toArray());
+    public void testJSONParsedSingleValue() {
+        SystemParsingRule parsingRule = new SystemParsingRule();
+        parsingRule.setParsingType(ParsingRuleType.JSON_PATH);
+        parsingRule.setExpression("$.string");
+        parsingRule.setMultiple(false);
+        parsingRule.setParamName("someJsonPathParam");
+        parsingRule.setParent(system);
+
+        Message message = createJsonMessage();
+
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertEquals("Hello World", result.getSingleValue());
     }
 
+    @Test
+    public void testJSONParsedMultipleValue() {
+        SystemParsingRule parsingRule = new SystemParsingRule();
+        parsingRule.setParsingType(ParsingRuleType.JSON_PATH);
+        parsingRule.setExpression("$.array");
+        parsingRule.setMultiple(true);
+        parsingRule.setParamName("someJsonPathParam");
+        parsingRule.setParent(system);
+        Message message = createJsonMessage();
 
-    private Message createJSONMessage() {
-        return new Message("{\n" +
-                "  \"array\": [\n" +
-                "    1,\n" +
-                "    2,\n" +
-                "    3\n" +
-                "  ],\n" +
-                "  \"boolean\": true,\n" +
-                "  \"null\": null,\n" +
-                "  \"number\": 123,\n" +
-                "  \"object\": {\n" +
-                "    \"a\": \"b\",\n" +
-                "    \"c\": \"d\",\n" +
-                "    \"e\": \"f\"\n" +
-                "  },\n" +
-                "  \"string\": \"Hello World\"\n" +
-                "}");
+        MessageParameter result = parsingRule.apply(message, InstanceContext.from(tcContext, null), false);
+
+        assertArrayEquals(new String[]{"1", "2", "3"}, result.getMultipleValue().toArray());
     }
 
-    private Message createMessage() throws ContentException {
-        return createMessage(this.text);
-    }
+    // ==================== HELPER METHODS ====================
 
-    private Message createMessage(String text) throws ContentException {
-        Message message = new Message();
-        message.setText(text);
-        message.setContent(new XmlContentProvider().provide(message));
-        return message;
-    }
-
-    private void setParents(ParsingRule parsingRule) {
-        System system = new System();
-        system.setName("SomeSystem");
-        Operation mock = mock(Operation.class);
-        when(mock.getName()).thenReturn("SomeOperation");
-        system.getOperations().add(mock);
-        when(mock.getParent()).thenReturn(system);
-        parsingRule.setParent(mock);
-    }
-
-    private ParsingRule createXpathParsingRule(String expression) {
-        ParsingRule parsingRule = new SystemParsingRule();
-        parsingRule.setParsingType(ParsingRuleType.XPATH);
-        parsingRule.setExpression(expression);
-        parsingRule.setName("SomeParsingRule");
+    private SystemParsingRule createUriRegexParsingRule(boolean multiple) {
+        SystemParsingRule parsingRule = new SystemParsingRule();
+        parsingRule.setParsingType(ParsingRuleType.REGEX_URI);
+        parsingRule.setMultiple(multiple);
+        parsingRule.setParamName("someRegexParam");
+        parsingRule.setExpression(".*/api/space/managed-domain/managed-elements/(\\S*)/equipment-holders/([^\\s/]*)$");
+        parsingRule.setParent(system);
         return parsingRule;
     }
 
+    private SystemParsingRule createXpathParsingRule(String expression) {
+        SystemParsingRule parsingRule = new SystemParsingRule();
+        parsingRule.setParsingType(ParsingRuleType.XPATH);
+        parsingRule.setExpression(expression);
+        parsingRule.setParamName("someXpathParam");
+        parsingRule.setParent(system);
+        return parsingRule;
+    }
+
+    private Message createMessageWithUriParams(String uriParams) throws ContentException {
+        Message message = new Message();
+        message.getConnectionProperties().put("uriParams", uriParams);
+        message.setContent(new PlainContentProvider().provide(message));
+        return message;
+    }
+
+    private Message createXmlMessage(String xmlContent) {
+        Message message = new Message();
+        message.setText(xmlContent);
+        try {
+            message.setContent(new XmlContentProvider().provide(message));
+        } catch (ContentException e) {
+            throw new RuntimeException("Failed to create XML message", e);
+        }
+        return message;
+    }
+
+    private Message createJsonMessage() {
+        Message message = new Message("{\n" +
+                "  \"array\": [1, 2, 3],\n" +
+                "  \"boolean\": true,\n" +
+                "  \"null\": null,\n" +
+                "  \"number\": 123,\n" +
+                "  \"object\": {\"a\": \"b\", \"c\": \"d\", \"e\": \"f\"},\n" +
+                "  \"string\": \"Hello World\"\n" +
+                "}");
+        try {
+            message.setContent(new JsonContentProvider().provide(message));
+        } catch (ContentException e) {
+            throw new RuntimeException("Failed to create JSON message", e);
+        }
+        return message;
+    }
 }

--- a/src/test/java/org/qubership/automation/itf/core/util/exception/ExceptionsTest.java
+++ b/src/test/java/org/qubership/automation/itf/core/util/exception/ExceptionsTest.java
@@ -1,0 +1,403 @@
+package org.qubership.automation.itf.core.util.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExceptionsTest {
+
+    // ==================== getMessagesOnly() TESTS ====================
+
+    @Test
+    public void getMessagesOnly_singleExceptionWithMessage() {
+        // Given
+        String exceptionMessage = "Database connection failed";
+        Exception exception = new Exception(exceptionMessage);
+
+        // When
+        String result = Exceptions.getMessagesOnly(exception);
+
+        // Then
+        assertEquals("Exception: " + exceptionMessage, result);
+    }
+
+    @Test
+    public void getMessagesOnly_singleExceptionWithNullMessage() {
+        // Given
+        Exception exception = new NullPointerException(); // message is null
+
+        // When
+        String result = Exceptions.getMessagesOnly(exception);
+
+        // Then
+        assertEquals("NullPointerException: ", result);
+    }
+
+    @Test
+    public void getMessagesOnly_chainedExceptions() {
+        // Given
+        String rootCauseMessage = "Invalid parameter: userId";
+        Exception rootCause = new IllegalArgumentException(rootCauseMessage);
+
+        String middleMessage = "Processing failed";
+        Exception middle = new RuntimeException(middleMessage, rootCause);
+
+        String topMessage = "Operation aborted";
+        Exception top = new Exception(topMessage, middle);
+
+        // When
+        String result = Exceptions.getMessagesOnly(top);
+
+        // Then
+        String expected = "Exception: " + topMessage + ":\n" +
+                "RuntimeException: " + middleMessage + ":\n" +
+                "IllegalArgumentException: " + rootCauseMessage;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getMessagesOnly_chainedWithNullMessages() {
+        // Given
+        Exception rootCause = new NullPointerException(); // message is null
+        Exception top = new RuntimeException(rootCause); // Once rootCause message is null, its class name is used
+
+        // When
+        String result = Exceptions.getMessagesOnly(top);
+
+        // Then
+        assertEquals("RuntimeException: java.lang.NullPointerException:\n"
+                + "NullPointerException: ", result); // all messages are null, but exceptions' class names are printed
+    }
+
+    @Test
+    public void getMessagesOnly_mixedNullAndNonNullMessages() {
+        // Given
+        String rootCauseMessage = "Root cause message";
+        Exception rootCause = new IllegalArgumentException(rootCauseMessage);
+
+        Exception middle = new NullPointerException(); // null message
+        middle.initCause(rootCause);
+
+        String topMessage = "Top message";
+        Exception top = new RuntimeException(topMessage, middle);
+
+        // When
+        String result = Exceptions.getMessagesOnly(top);
+
+        // Then
+        String expected = "RuntimeException: " + topMessage + ":\n"
+                + "NullPointerException: :\n"
+                + "IllegalArgumentException: " + rootCauseMessage;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getMessagesOnly_withNullInput() {
+        // When/Then - should not throw NPE
+        String result = Exceptions.getMessagesOnly(null);
+
+        // Then
+        assertEquals("", result); // Joiner.on(":\n").join(empty list) returns empty string
+    }
+
+    // ==================== fillWithBriefInfo() TESTS ====================
+
+    @Test
+    public void fillWithBriefInfo_withCoreException() {
+        // Given
+        String message = "Core error occurred";
+        StringBuilder sb = new StringBuilder();
+        CoreException coreException = new CoreException(message);
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, coreException);
+
+        // Then
+        assertEquals("CoreException: " + message, sb.toString());
+    }
+
+    @Test
+    public void fillWithBriefInfo_withCoreExceptionAndNullMessage() {
+        // Given
+        StringBuilder sb = new StringBuilder();
+        CoreException coreException = new CoreException((String) null);
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, coreException);
+
+        // Then
+        assertEquals("CoreException: ", sb.toString());
+    }
+
+    @Test
+    public void fillWithBriefInfo_withNonCoreExceptionWithoutCause() {
+        // Given
+        StringBuilder sb = new StringBuilder();
+        Exception regularException = new IllegalArgumentException("Invalid argument");
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, regularException);
+
+        // Then
+        String result = sb.toString();
+        assertTrue(result.startsWith("java.lang.IllegalArgumentException: Invalid argument\n"));
+    }
+
+    @Test
+    public void fillWithBriefInfo_withNonCoreException_chained() {
+        // Given
+        StringBuilder sb = new StringBuilder();
+        Exception rootCause = new ArithmeticException("Division by zero");
+        Exception topException = new RuntimeException("Calculation error", rootCause);
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, topException);
+
+        // Then
+        String result = sb.toString();
+        assertTrue(result.startsWith("RuntimeException: Calculation error\n"
+                + "java.lang.ArithmeticException: Division by zero\n"));
+    }
+
+    @Test
+    public void fillWithBriefInfo_withNonCoreExceptionAndNullMessages() {
+        // Given
+        StringBuilder sb = new StringBuilder();
+        Exception rootCause = new NullPointerException(); // null message
+        Exception topException = new RuntimeException(rootCause);
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, topException);
+
+        // Then
+        String result = sb.toString();
+        assertTrue(result.startsWith("RuntimeException: java.lang.NullPointerException\n"
+                + "java.lang.NullPointerException\n"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void fillWithBriefInfo_withNullStringBuilder_throwsNPE() {
+        // When
+        Exceptions.fillWithBriefInfo(null, new Exception());
+    }
+
+    @Test
+    public void fillWithBriefInfo_withNullThrowable_resultsEmptyString() {
+        // Given
+        StringBuilder sb = new StringBuilder();
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, null);
+
+        // Then
+        String result = sb.toString();
+        assertTrue(result.isEmpty());
+    }
+
+    // ==================== getExceptionSummary() TESTS ====================
+
+    @Test
+    public void getExceptionSummary_withNullInput() {
+        // When
+        String result = Exceptions.getExceptionSummary(null);
+
+        // Then
+        assertEquals("null exception", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withNormalMessage() {
+        // Given
+        String message = "Something went wrong";
+        Exception exception = new Exception(message);
+
+        // When
+        String result = Exceptions.getExceptionSummary(exception);
+
+        // Then
+        assertEquals(message, result);
+    }
+
+    @Test
+    public void getExceptionSummary_withEmptyMessage() {
+        // Given
+        Exception exception = new Exception("");
+
+        // When
+        String result = Exceptions.getExceptionSummary(exception);
+
+        // Then
+        assertEquals("Exception", result); // falls back to class name
+    }
+
+    @Test
+    public void getExceptionSummary_withBlankMessage() {
+        // Given
+        Exception exception = new Exception("   ");
+
+        // When
+        String result = Exceptions.getExceptionSummary(exception);
+
+        // Then
+        assertEquals("Exception", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withNullMessage_fallsBackToClassName() {
+        // Given
+        Exception exception = new NullPointerException(); // message is null
+
+        // When
+        String result = Exceptions.getExceptionSummary(exception);
+
+        // Then
+        assertEquals("NullPointerException", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withNullMessageButCauseHasMessage() {
+        // Given
+        IllegalArgumentException cause = new IllegalArgumentException("Invalid ID format");
+        Exception topException = new RuntimeException(null, cause); // null message
+
+        // When
+        String result = Exceptions.getExceptionSummary(topException);
+
+        // Then
+        assertEquals("RuntimeException, caused by: Invalid ID format", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withNullMessageAndCauseAlsoHasNullMessage() {
+        // Given
+        NullPointerException cause = new NullPointerException(); // null message
+        Exception topException = new RuntimeException(null, cause);
+
+        // When
+        String result = Exceptions.getExceptionSummary(topException);
+
+        // Then
+        assertEquals("RuntimeException, caused by: NullPointerException", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withDeepCauseChain() {
+        // Given
+        Exception rootCause = new IllegalArgumentException("Root cause");
+        Exception middle = new RuntimeException(null, rootCause);
+        Exception top = new Exception(null, middle);
+
+        // When
+        String result = Exceptions.getExceptionSummary(top);
+
+        // Then
+        // Only exception itself and its cause are checked, not deeper
+        assertEquals("Exception, caused by: RuntimeException", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withSelfCausingException_protectsAgainstRecursion() throws Exception {
+        // 1. Create common exception
+        Exception circular = new Exception("Test message");
+
+        // 2. Via Reflection, we forcibly set cause to itself
+        //    It emulates broken object (which can't be created via constructors/setters),
+        //    produced by means of deserializing.
+        Field causeField = Throwable.class.getDeclaredField("cause");
+        causeField.setAccessible(true);
+        causeField.set(circular, circular); // Bypass check of initCause()
+
+        // 3. Also, one should turn off flag, which is used by Throwable for checks.
+        //    Depending on JDK version, it can be 'cause' or 'suppressedExceptions' field.
+        //    It's enough for the majority of versions.
+
+        // 4. Invoke our method
+        String result = Exceptions.getExceptionSummary(circular);
+
+        // 5. Check that the method isn't in the infinite recursion and returned normal result
+        //    Expect simple exception message
+        assertNotNull(result);
+        assertTrue(result.contains("Test message") || result.contains("Exception"));
+    }
+
+    @Test
+    public void getExceptionSummary_withCustomException() {
+        // Given
+        class CustomException extends Exception {
+            CustomException(String message) { super(message); }
+        }
+        CustomException custom = new CustomException("Custom error occurred");
+
+        // When
+        String result = Exceptions.getExceptionSummary(custom);
+
+        // Then
+        assertEquals("Custom error occurred", result);
+    }
+
+    @Test
+    public void getExceptionSummary_withCoreException() {
+        // Given
+        CoreException coreException = new CoreException("Core business error");
+
+        // When
+        String result = Exceptions.getExceptionSummary(coreException);
+
+        // Then
+        assertEquals("Core business error", result);
+    }
+
+    // ==================== Edge Cases ====================
+
+    @Test
+    public void getExceptionSummary_withVeryLongMessage() {
+        // Given
+        String longMessage = StringUtils.repeat("AAAAA", 2000);
+        Exception exception = new Exception(longMessage);
+
+        // When
+        String result = Exceptions.getExceptionSummary(exception);
+
+        // Then
+        assertEquals(longMessage, result);
+    }
+
+    @Test
+    public void getMessagesOnly_withVeryDeepChain() {
+        // Given
+        Throwable current = new Exception("Level 1");
+        for (int i = 2; i <= 100; i++) {
+            current = new Exception("Level " + i, current);
+        }
+
+        // When
+        String result = Exceptions.getMessagesOnly(current);
+
+        // Then
+        assertTrue(result.contains("Level 100"));
+        assertTrue(result.contains("Level 1"));
+        assertTrue(result.split(":\n").length >= 100);
+    }
+
+    @Test
+    public void fillWithBriefInfo_appendsToExistingStringBuilderContent() {
+        // Given
+        StringBuilder sb = new StringBuilder("Prefix: ");
+        Exception exception = new Exception("Test error");
+
+        // When
+        Exceptions.fillWithBriefInfo(sb, exception);
+
+        // Then
+        assertTrue(sb.toString().startsWith("Prefix: "));
+        assertTrue(sb.toString().contains("Test error"));
+    }
+}


### PR DESCRIPTION
### Why
Connection to internal service database (itf-executor / itf-reporting services), is configured via Hikari dataSource configuration. 
This configuration contains _spring.datasource.hikari.max-lifetime_ property with positive value 3960000 ms = 66 minutes.
So, after 66 minutes connection is closed and removed from the pool.
Also, _idle timeout_ and _keepalive time_ are not configured properly.
It entails sudden "Connection closed" exceptions faced in java code using Hibernate middleware between java code and Hikari.

### What
_Max-lifetime_ default value is set to 0 (no lifetime check).
_idle timeout_ and _keepalive time_ are set to proper values, ensuring that idle connections will not be considered as dead by the database.
Also, parameters _tcpKeepAlive_ and _socketTimeout_ are added to jdbc Url.

These changes are made for _atp.multi-tenancy.enabled=false_ configuration (Multitenancy configuration is served by **multitenancy library**, so almost the same changes are to be implemented there).

### Extra changes
- A new Exceptions#getExceptionSummary method is implemented to produce short informative exception message even in case top exception and its cause messages are null. Unit test is implemented for Exceptions class.
- ParsingRuleTest is rewritten.

<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/268d4a074ed8dcb23f1621d1234bab35a5e5a06e) fix: CommonHibernateConfiguration#getDataSource: Hikari configuration is fixed to improve connections management. Project version is set to 4.4.116-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/f9ff1beaedf68fbb570394b4a1a0c4b68e18fc23) feat: Exceptions class: new 'getExceptionSummary' method is implemented, 'fillWithBriefInfo' is fixed. Unit tests are added. Bump dependencies: junit to 4.13.2, mockito-core to 4.11.0. Project version is set to 4.4.117-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/8ae471210cf60d3ee67b68fae2734be2e7213dfe) fix(tests): ParsingRuleTest is rewritten and fixed, jaxen:jaxen:1.1.6:test dependency is added. InterceptorChainTest is temporarily disabled.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/e99d0b6845cf5c47cc12b8bb36b326f274fa19ed) build: Project version set to 4.4.115-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/58d340bf880baf0effc6b6bb1593c7c40b17642e) fix(docs): MARKDOWN and NATURAL_LANGUAGE linters errors are fixed.
<!-- end messages -->

