### PR TITLE
fix: Fix projectSettingsService bean definition to avoid beans duplicating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-itf-core</artifactId>
-    <version>5.1.31-SNAPSHOT</version>
+    <version>5.1.32-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-itf-core</artifactId>
-    <version>5.1.30-SNAPSHOT</version>
+    <version>5.1.31-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
+++ b/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
+++ b/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 public class ProjectSettingsServiceConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(ProjectSettingsService.class)
+    @ConditionalOnMissingBean(name = "projectSettingsService")
     public ProjectSettingsService projectSettingsService() {
         return new ProjectSettingsService();
     }

--- a/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
+++ b/src/main/java/org/qubership/automation/itf/core/util/services/projectsettings/config/ProjectSettingsServiceConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.qubership.automation.itf.core.util.services.projectsettings.config;
 
-import org.qubership.automation.itf.core.util.services.projectsettings.AbstractProjectSettingsService;
 import org.qubership.automation.itf.core.util.services.projectsettings.ProjectSettingsService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 public class ProjectSettingsServiceConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(AbstractProjectSettingsService.class)
+    @ConditionalOnMissingBean(ProjectSettingsService.class)
     public ProjectSettingsService projectSettingsService() {
         return new ProjectSettingsService();
     }


### PR DESCRIPTION
The problem:
- projectSettingsService bean is defined in itf-core library,
- and there is co-named bean in 1) itf-stubs service and 2) itf-executor service,
- annotations on these beans don't prevent initializing of both beans.

So Spring Application start fails wih 'beans duplicated' exception.
Currently, it's managed via config setting spring.main.allow-bean-definition-overriding=true.
But, this setting isn't recommended by Spring.

This PR fixes the problem via changing @ConditionalOnMissingBean annotation in the library and adding @Primary annotation in services.
<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/698dab8421248bc69e7c80b63a4f174825955d3d) fix: Fix duplicating of ProjectSettingsService bean. Change version to 5.1.31-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/9d838354468ebbfba8e817181f6216fa1c9ea702) fix: Fix duplicating of ProjectSettingsService bean.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-itf-core-library/commit/b3a0aa5a7e51fce0631cdf8c3c67edd5d019feb7) fix: Fix duplicating of ProjectSettingsService bean. Change version to 5.1.32-SNAPSHOT.
<!-- end messages -->
